### PR TITLE
Use Gradle Wrapper

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd ..
-gradle build -x test
+./gradlew build -x test
 docker compose -f docker-compose-docker.yml up


### PR DESCRIPTION
Проект использует Gradle Wrapper (в корне проекта есть файлы gradlew и gradlew.bat). Лучше будет использовать их вместо установленного в системе, например в Ubuntu до сих пор gradle версии 4.4.1, а нужно 8+.