### PR TITLE
Fix sql script encoding

### DIFF
--- a/src/test/java/org/itmo/eventApp/main/controller/AbstractTestContainers.java
+++ b/src/test/java/org/itmo/eventApp/main/controller/AbstractTestContainers.java
@@ -127,6 +127,7 @@ public abstract class AbstractTestContainers {
         ResourceDatabasePopulator resourceDatabasePopulator = new ResourceDatabasePopulator();
         resourceDatabasePopulator.addScript(new ClassPathResource(sqlFileName));
 //        resourceDatabasePopulator.setSeparator("@@");
+        resourceDatabasePopulator.setSqlScriptEncoding("UTF-8");
         resourceDatabasePopulator.execute(dataSource);
     }
 

--- a/src/test/resources/db/test-migration/V0_3__fill_tables_test.sql
+++ b/src/test/resources/db/test-migration/V0_3__fill_tables_test.sql
@@ -52,7 +52,7 @@ VALUES
     ('EXPORT_PARTICIPANT_LIST_XLSX', 'EVENT','Экспорт списка участников в формате xlsx'),
     ('WORK_WITH_PARTICIPANT_LIST', 'EVENT','Работа со списком участников');
 
-INSERT INTO role_privilege(role_id, privilege_id) values (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9),(1,10),(1,11),(1,12),(1,13),(1,14),(1,15),(1,16),(1,17),(1,18),(1,19),(1,23),(1,24),(1,28);
+INSERT INTO role_privilege(role_id, privilege_id) values (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9),(1,11),(1,12),(1,13),(1,14),(1,15),(1,16),(1,17),(1,18),(1,19),(1,23),(1,24),(1,28);
 Insert into role_privilege(role_id, privilege_id) VALUES (2,3),(2,5),(2,6),(2,8),(2,9),(2,28);
 Insert into role_privilege(role_id, privilege_id) VALUES (3,10),(3,20),(3,21),(3,22),(3,23),(3,24),(3,25),(3,26),(3,27),(3,29),(3,30),(3,31),(3,32),(3,33),(3,34),(3,35),(3,36),(3,37),(3,38),(3,39),(3,40),(3,41),(3,42),(3,43),(3,44);
 Insert into role_privilege(role_id, privilege_id) VALUES (4,23),(4,24),(4,38),(4,39),(4,40),(4,41),(4,42),(4,43),(4,44);


### PR DESCRIPTION
При запуске тестов во время _gradle build_ возникают проблемы с кодировкой в тестах RoleServiceTest.
В частности:
- [createRole]-(Neg) Creating a new role using a NON-unique name
- [createRole]-(Neg) Creating a new role using a NON-unique name
- [deleteRole]-(Neg) Deleting role which is BASIC & can NOT be deleted
- [editRole]-(Neg) Editing role which is BASIC & can NOT be modified
- [editRole]-(Neg) Editing role using NON-unique name
- [findRoleById]-(Pos) Getting BASIC roles by Id
- [findByName]-(Pos) Getting BASIC roles by name
- [get(Basic)Role]-(Pos) Getting BASIC roles
- [findRoleById]-(Pos) Getting FAKE roles by Id
- [findByName]-(Pos) Getting FAKE roles by name
- [searchByName]-(Pos) Getting BASIC roles by name
- [searchByName]-(Pos) Getting FAKE roles by name